### PR TITLE
feat: add custom 404 page matching paper theme

### DIFF
--- a/crm-dashboard/src/app/not-found.tsx
+++ b/crm-dashboard/src/app/not-found.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { FileQuestion } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-[#FDFBF7] flex items-center justify-center px-4">
+      <div className="text-center max-w-md">
+        <div className="flex justify-center mb-6">
+          <div className="rounded-full bg-[#F3EFE7] p-6">
+            <FileQuestion className="h-10 w-10 text-gray-600" />
+          </div>
+        </div>
+
+        <h1 className="font-serif text-3xl text-gray-900 mb-3">
+          Looks like this sheet is missing
+        </h1>
+
+        <p className="text-gray-600 mb-6">
+          The page you’re looking for doesn’t exist or was moved.
+        </p>
+
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center justify-center rounded-md bg-black px-5 py-2.5 text-sm font-medium text-white hover:bg-gray-800 transition"
+        >
+          Back to Dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Replaces the default Next.js 404 page with a custom not-found page that matches the Sheety CRM paper theme. This keeps the user experience visually consistent when navigating to invalid routes.

## Type of Change
- [x] New feature

## Testing
- Navigated to a non-existent route to verify the custom 404 page renders correctly.
- Confirmed typography, background, and CTA styling match the existing paper theme.
- Verified the "Back to Dashboard" button navigates correctly.

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [ ] Updated documentation if needed
- [x] No new warnings
