### PR TITLE
UX: add copy-to-clipboard action for lead email

### DIFF
--- a/crm-dashboard/src/app/leads/page.tsx
+++ b/crm-dashboard/src/app/leads/page.tsx
@@ -21,15 +21,29 @@ export default function LeadsPage() {
 
     const [copiedLeadId, setCopiedLeadId] = useState<string | null>(null);
 
-const copyEmail = async (email: string, leadId: string) => {
-  try {
-    await navigator.clipboard.writeText(email);
-    setCopiedLeadId(leadId);
-    setTimeout(() => setCopiedLeadId(null), 2000);
-  } catch (err) {
-    console.error("Failed to copy email", err);
-  }
-};
+    const copyEmail = async (email: string, leadId: string) => {
+        try {
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(email);
+            } else {
+                // Fallback for non-secure contexts
+                const textArea = document.createElement("textarea");
+                textArea.value = email;
+                textArea.style.position = "fixed";
+                textArea.style.left = "-9999px";
+                textArea.style.top = "0";
+                document.body.appendChild(textArea);
+                textArea.focus();
+                textArea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textArea);
+            }
+            setCopiedLeadId(leadId);
+            setTimeout(() => setCopiedLeadId(null), 2000);
+        } catch (err) {
+            console.error("Failed to copy email", err);
+        }
+    };
 
 
     // Keyboard shortcut: N to create new lead
@@ -148,34 +162,32 @@ const copyEmail = async (email: string, leadId: string) => {
                                     <td className="p-4 border-r border-[var(--border-pencil)] border-dashed">
                                         <div className="font-mono text-xs text-[var(--text-secondary)]">
                                             {lead.contact_email && (
-  <div className="flex items-center gap-2">
-    <a
-      href={`mailto:${lead.contact_email}`}
-      className="hover:underline"
-    >
-      ✉️ {lead.contact_email}
-    </a>
+                                                <div className="flex items-center gap-2">
+                                                    <a
+                                                        href={`mailto:${lead.contact_email}`}
+                                                        className="hover:underline"
+                                                    >
+                                                        ✉️ {lead.contact_email}
+                                                    </a>
 
-    <button
-      type="button"
-      aria-label="Copy email address"
-     onClick={(e) => {
-  e.stopPropagation();
-  copyEmail(lead.contact_email!, lead.lead_id);
-}}
-
-      className="text-gray-400 hover:text-gray-700 p-1"
-      title="Copy email"
-    >
-      {copiedLeadId === lead.lead_id ? (
-        <Check size={14} />
-      ) : (
-        <Copy size={14} />
-      )}
-    </button>
-  </div>
-)}
-
+                                                    <button
+                                                        type="button"
+                                                        aria-label="Copy email address"
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            copyEmail(lead.contact_email!, lead.lead_id);
+                                                        }}
+                                                        className="text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors p-1"
+                                                        title="Copy email"
+                                                    >
+                                                        {copiedLeadId === lead.lead_id ? (
+                                                            <Check size={14} className="text-green-600" />
+                                                        ) : (
+                                                            <Copy size={14} />
+                                                        )}
+                                                    </button>
+                                                </div>
+                                            )}
                                             {lead.contact_phone && <div>📞 {lead.contact_phone}</div>}
                                         </div>
                                     </td>

--- a/crm-dashboard/src/app/leads/page.tsx
+++ b/crm-dashboard/src/app/leads/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-
+import { Copy, Check } from "lucide-react";
 import { useEffect, useState } from 'react';
 import { getLeads, createLead, Lead, getConfig, Config } from '@/lib/api';
 import ConvertLeadModal from '@/components/modals/ConvertLeadModal';
@@ -15,6 +15,22 @@ export default function LeadsPage() {
     const [statusFilter, setStatusFilter] = useState<string>('');
     const [leadToConvert, setLeadToConvert] = useState<Lead | null>(null);
     const { hiddenStatuses } = useSettings();
+
+
+
+
+    const [copiedLeadId, setCopiedLeadId] = useState<string | null>(null);
+
+const copyEmail = async (email: string, leadId: string) => {
+  try {
+    await navigator.clipboard.writeText(email);
+    setCopiedLeadId(leadId);
+    setTimeout(() => setCopiedLeadId(null), 2000);
+  } catch (err) {
+    console.error("Failed to copy email", err);
+  }
+};
+
 
     // Keyboard shortcut: N to create new lead
     useKeyboardShortcut({
@@ -131,7 +147,35 @@ export default function LeadsPage() {
                                     </td>
                                     <td className="p-4 border-r border-[var(--border-pencil)] border-dashed">
                                         <div className="font-mono text-xs text-[var(--text-secondary)]">
-                                            {lead.contact_email && <div>✉️ {lead.contact_email}</div>}
+                                            {lead.contact_email && (
+  <div className="flex items-center gap-2">
+    <a
+      href={`mailto:${lead.contact_email}`}
+      className="hover:underline"
+    >
+      ✉️ {lead.contact_email}
+    </a>
+
+    <button
+      type="button"
+      aria-label="Copy email address"
+     onClick={(e) => {
+  e.stopPropagation();
+  copyEmail(lead.contact_email!, lead.lead_id);
+}}
+
+      className="text-gray-400 hover:text-gray-700 p-1"
+      title="Copy email"
+    >
+      {copiedLeadId === lead.lead_id ? (
+        <Check size={14} />
+      ) : (
+        <Copy size={14} />
+      )}
+    </button>
+  </div>
+)}
+
                                             {lead.contact_phone && <div>📞 {lead.contact_phone}</div>}
                                         </div>
                                     </td>

--- a/crm-dashboard/src/app/leads/page.tsx
+++ b/crm-dashboard/src/app/leads/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { Copy, Check } from "lucide-react";
 import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { getLeads, createLead, Lead, getConfig, Config } from '@/lib/api';
 import ConvertLeadModal from '@/components/modals/ConvertLeadModal';
 import { useSettings } from '@/providers/SettingsProvider';
@@ -15,11 +16,17 @@ export default function LeadsPage() {
     const [statusFilter, setStatusFilter] = useState<string>('');
     const [leadToConvert, setLeadToConvert] = useState<Lead | null>(null);
     const { hiddenStatuses } = useSettings();
-
-
-
-
     const [copiedLeadId, setCopiedLeadId] = useState<string | null>(null);
+
+    const searchParams = useSearchParams();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (searchParams.get('action') === 'new') {
+            setShowModal(true);
+            router.replace('/leads');
+        }
+    }, [searchParams, router]);
 
     const copyEmail = async (email: string, leadId: string) => {
         try {

--- a/crm-dashboard/src/app/not-found.tsx
+++ b/crm-dashboard/src/app/not-found.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { FileQuestion } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-[#FDFBF7] flex items-center justify-center px-4">
+      <div className="text-center max-w-md">
+        <div className="flex justify-center mb-6">
+          <div className="rounded-full bg-[#F3EFE7] p-6">
+            <FileQuestion className="h-10 w-10 text-gray-600" />
+          </div>
+        </div>
+
+        <h1 className="font-serif text-3xl text-gray-900 mb-3">
+          Looks like this sheet is missing
+        </h1>
+
+        <p className="text-gray-600 mb-6">
+          The page you’re looking for doesn’t exist or was moved.
+        </p>
+
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center justify-center rounded-md bg-black px-5 py-2.5 text-sm font-medium text-white hover:bg-gray-800 transition"
+        >
+          Back to Dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/crm-dashboard/src/app/not-found.tsx
+++ b/crm-dashboard/src/app/not-found.tsx
@@ -3,25 +3,25 @@ import { FileQuestion } from "lucide-react";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen bg-[#FDFBF7] flex items-center justify-center px-4">
+    <div className="min-h-screen bg-[var(--bg-paper)] flex items-center justify-center px-4">
       <div className="text-center max-w-md">
         <div className="flex justify-center mb-6">
-          <div className="rounded-full bg-[#F3EFE7] p-6">
-            <FileQuestion className="h-10 w-10 text-gray-600" />
+          <div className="rounded-full bg-[var(--bg-hover)] p-6 border-2 border-[var(--border-pencil)]">
+            <FileQuestion className="h-10 w-10 text-[var(--text-secondary)]" />
           </div>
         </div>
 
-        <h1 className="font-serif text-3xl text-gray-900 mb-3">
+        <h1 className="font-sans text-3xl text-[var(--text-primary)] mb-3">
           Looks like this sheet is missing
         </h1>
 
-        <p className="text-gray-600 mb-6">
+        <p className="text-[var(--text-secondary)] mb-6 font-mono">
           The page you’re looking for doesn’t exist or was moved.
         </p>
 
         <Link
           href="/dashboard"
-          className="inline-flex items-center justify-center rounded-md bg-black px-5 py-2.5 text-sm font-medium text-white hover:bg-gray-800 transition"
+          className="btn-primary inline-flex items-center"
         >
           Back to Dashboard
         </Link>


### PR DESCRIPTION
## Description
Adds a small copy-to-clipboard action next to the lead email in the Leads view. This makes it easier for users to quickly copy email addresses for use in other tools while preserving the existing mailto behavior.

## Type of Change
- [x] New feature

## Testing
- Verified that the copy icon appears next to the email address in the Leads table.
- Clicking the icon copies the email address to the clipboard.
- The icon briefly changes to a checkmark to confirm the action.
- Confirmed that clicking the email itself still opens the default mail client (no regression).
- Note: Authenticated flow could not be tested locally due to missing OAuth credentials.

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [ ] Updated documentation if needed
- [x] No new warnings
