### PR TITLE
UI: route-change loading indicator (nprogress)

### DIFF
--- a/crm-dashboard/package-lock.json
+++ b/crm-dashboard/package-lock.json
@@ -18,6 +18,7 @@
         "lucide-react": "^0.562.0",
         "next": "16.1.2",
         "next-auth": "^5.0.0-beta.30",
+        "nprogress": "^0.2.0",
         "posthog-js": "^1.328.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -7002,6 +7003,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
+      "license": "MIT"
+    },
     "node_modules/oauth4webapi": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.3.tgz",
@@ -7672,7 +7679,6 @@
         "@types/react": {
           "optional": true
         }
-
       }
     },
     "node_modules/readdirp": {

--- a/crm-dashboard/package-lock.json
+++ b/crm-dashboard/package-lock.json
@@ -31,6 +31,7 @@
         "@tailwindcss/postcss": "^4",
         "@tailwindcss/typography": "^0.5.19",
         "@types/node": "^20",
+        "@types/nprogress": "^0.2.3",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/react-joyride": "^2.0.2",
@@ -2671,6 +2672,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/nprogress": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@types/nprogress/-/nprogress-0.2.3.tgz",
+      "integrity": "sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.8",

--- a/crm-dashboard/package.json
+++ b/crm-dashboard/package.json
@@ -22,6 +22,7 @@
     "lucide-react": "^0.562.0",
     "next": "16.1.2",
     "next-auth": "^5.0.0-beta.30",
+    "nprogress": "^0.2.0",
     "posthog-js": "^1.328.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/crm-dashboard/package.json
+++ b/crm-dashboard/package.json
@@ -35,6 +35,7 @@
     "@tailwindcss/postcss": "^4",
     "@tailwindcss/typography": "^0.5.19",
     "@types/node": "^20",
+    "@types/nprogress": "^0.2.3",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/react-joyride": "^2.0.2",

--- a/crm-dashboard/src/app/globals.css
+++ b/crm-dashboard/src/app/globals.css
@@ -511,3 +511,35 @@ code,
 .pb-safe {
   padding-bottom: env(safe-area-inset-bottom);
 }
+
+/* NProgress (route change progress bar) */
+#nprogress {
+  pointer-events: none;
+}
+
+#nprogress .bar {
+  background: var(--text-primary);
+  position: fixed;
+  z-index: 1031;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+}
+
+#nprogress .peg {
+  display: block;
+  position: absolute;
+  right: 0px;
+  width: 100px;
+  height: 100%;
+  box-shadow:
+    0 0 10px var(--text-primary),
+    0 0 5px var(--text-primary);
+  opacity: 1;
+  transform: rotate(3deg) translate(0px, -4px);
+}
+
+#nprogress .spinner {
+  display: none;
+}

--- a/crm-dashboard/src/app/layout.tsx
+++ b/crm-dashboard/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { SettingsProvider } from "@/providers/SettingsProvider";
 import { KeyboardShortcutsProvider } from "@/providers/KeyboardShortcutsContext";
 import CommandPalette from "@/components/CommandPalette";
 import MobileBottomNav from "@/components/MobileBottomNav";
+import NavigationProgress from "@/components/NavigationProgress";
 import { Suspense } from "react";
 
 const sans = Outfit({
@@ -67,6 +68,7 @@ export default function RootLayout({
         className={`${sans.variable} ${mono.variable} ${serif.variable} antialiased font-sans`}
       >
         <PostHogProvider>
+          <NavigationProgress />
           <Suspense fallback={null}>
             <PostHogPageView />
           </Suspense>

--- a/crm-dashboard/src/app/layout.tsx
+++ b/crm-dashboard/src/app/layout.tsx
@@ -68,8 +68,8 @@ export default function RootLayout({
         className={`${sans.variable} ${mono.variable} ${serif.variable} antialiased font-sans`}
       >
         <PostHogProvider>
-          <NavigationProgress />
           <Suspense fallback={null}>
+            <NavigationProgress />
             <PostHogPageView />
           </Suspense>
           <SessionProvider>

--- a/crm-dashboard/src/components/NavigationProgress.tsx
+++ b/crm-dashboard/src/components/NavigationProgress.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import NProgress from "nprogress";
+
+const isModifiedEvent = (event: MouseEvent) =>
+  event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
+
+const isInternalHref = (href: string) => {
+  try {
+    // Support relative URLs.
+    const url = new URL(href, window.location.href);
+    return url.origin === window.location.origin;
+  } catch {
+    return false;
+  }
+};
+
+export default function NavigationProgress() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    NProgress.configure({ showSpinner: false });
+
+    const handleClick = (event: MouseEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.button !== 0) return;
+      if (isModifiedEvent(event)) return;
+
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest("a");
+      if (!anchor) return;
+
+      const href = anchor.getAttribute("href");
+      if (!href) return;
+
+      // Ignore hash-only navigation.
+      if (href.startsWith("#")) return;
+
+      // Ignore downloads and external targets.
+      if (anchor.hasAttribute("download")) return;
+      if (anchor.target && anchor.target !== "_self") return;
+
+      // Ignore external links.
+      if (!isInternalHref(href)) return;
+
+      NProgress.start();
+    };
+
+    const handlePopState = () => {
+      NProgress.start();
+    };
+
+    document.addEventListener("click", handleClick);
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      document.removeEventListener("click", handleClick);
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, []);
+
+  useEffect(() => {
+    // Route transition finished.
+    NProgress.done();
+  }, [pathname, searchParams]);
+
+  return null;
+}


### PR DESCRIPTION
Refs #3

Adds a top progress bar for client-side navigations to reduce perceived jank on route changes.

- Adds `nprogress` dependency
- Adds a `NavigationProgress` client component (starts on internal link clicks/back-forward; completes on pathname/search change)
- Styles the bar to match the app theme